### PR TITLE
KSHT-229 Handle 'none' update_type to skip auto-merge

### DIFF
--- a/action/lib/parse.js
+++ b/action/lib/parse.js
@@ -109,7 +109,7 @@ export default function ({ title, labels = [], config = [], dependencies = {} })
 
       switch (true) {
         case update_type === 'none':
-          core.info(`${dependency_name || dependency_type}:${update_type} detected, will skip auto-merge because update_type is none`)
+          core.warning(`${dependency_name || dependency_type}:${update_type} detected, skipping auto-merge because update_type is none`)
           return process.exit(0) // soft exit
 
         case update_type === 'in_range':

--- a/action/lib/parse.js
+++ b/action/lib/parse.js
@@ -107,6 +107,7 @@ export default function ({ title, labels = [], config = [], dependencies = {} })
     ) {
       core.info(`config: ${dependency_name || dependency_type}:${update_type}`)
 
+      core.warning('Now in parse.js!!!!!!!!!')
       switch (true) {
         case update_type === 'none':
           core.warning(`${dependency_name || dependency_type}:${update_type} detected, skipping auto-merge because update_type is none`)

--- a/action/lib/parse.js
+++ b/action/lib/parse.js
@@ -110,7 +110,7 @@ export default function ({ title, labels = [], config = [], dependencies = {} })
       switch (true) {
         case update_type === 'none':
           core.warning(`${dependency_name || dependency_type}:${update_type} detected, skipping auto-merge because update_type is none`)
-          return process.exit(0) // soft exit
+          return false
 
         case update_type === 'in_range':
           core.warning('in_range update type not supported yet (some text to check if the new version is used)')

--- a/action/lib/parse.js
+++ b/action/lib/parse.js
@@ -113,7 +113,7 @@ export default function ({ title, labels = [], config = [], dependencies = {} })
           return process.exit(0) // soft exit
 
         case update_type === 'in_range':
-          core.warning('in_range update type not supported yet')
+          core.warning('in_range update type not supported yet (some text to check if the new version is used)')
           return process.exit(0) // soft exit
 
         case update_type === 'all':

--- a/action/lib/parse.js
+++ b/action/lib/parse.js
@@ -108,6 +108,10 @@ export default function ({ title, labels = [], config = [], dependencies = {} })
       core.info(`config: ${dependency_name || dependency_type}:${update_type}`)
 
       switch (true) {
+        case update_type === 'none':
+          core.info(`${dependency_name || dependency_type}:${update_type} detected, will skip auto-merge because update_type is none`)
+          return process.exit(0) // soft exit
+
         case update_type === 'in_range':
           core.warning('in_range update type not supported yet')
           return process.exit(0) // soft exit


### PR DESCRIPTION
Add a case to exit the process early when the update_type is 'none'. This prevents auto-merge attempts on dependencies with no changes, ensuring proper flow and clarity in the update process.

## What

Explain what changes inside the code, this can be as simple or complicated as you want as long as it's clear

## Why

Explain why these things are changes. This explanation is for your colleagues and your future self.

## Code Review

Please consider the following checklist when reviewing this Pull Request.  
More background and details [here](https://github.com/kabisa/kabisa-guide/blob/master/organization/process/code-review/README.md).

* [ ] Does the code **actually solve** the problem it was meant to solve?
* [ ] Is the code covered by **unit tests**? **Integration tests**?
* [ ] Does anything here need **documentation**? (Focus on *why*, not *what.*)
* [ ] Does any of this code deal with **privacy sensitive information** or affects **security**? Ask an additional reviewer.
* [ ] Is the code easy to **understand** and **change** in the future?
* [ ] Is the same code or concept **duplicated**? Find a balance between DRYness and readability.
* [ ] Does the code reasonably adhere to the Kabisa [**coding standards**](https://github.com/kabisa/kabisa-guide/blob/master/organization/process/code-review/README.md)?
* [ ] Be kind.
